### PR TITLE
PlayScene - remove Composite Collider from ball

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -1793,7 +1793,6 @@ GameObject:
   - component: {fileID: 1864824152}
   - component: {fileID: 1864824151}
   - component: {fileID: 1864824154}
-  - component: {fileID: 1864824153}
   m_Layer: 0
   m_Name: Ball
   m_TagString: Untagged
@@ -1831,8 +1830,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   rightScored: 0
   leftScored: 0
-  nextRound: 0
-  loadDelay: 2
 --- !u!50 &1864824152
 Rigidbody2D:
   serializedVersion: 5
@@ -1860,65 +1857,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!66 &1864824153
-CompositeCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864824149}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_GeometryType: 1
-  m_GenerationType: 0
-  m_EdgeRadius: 0
-  m_ColliderPaths:
-  - m_Collider: {fileID: 1864824154}
-    m_ColliderPaths:
-    - - X: 5000000
-        Y: 5000000
-      - X: -5000000
-        Y: 5000000
-      - X: -5000000
-        Y: -5000000
-      - X: 5000000
-        Y: -5000000
-  m_CompositePaths:
-    m_Paths:
-    - - {x: 0.4999707, y: -0.5}
-      - {x: 0.4999707, y: 0.5}
-      - {x: -0.5, y: 0.4999707}
-      - {x: -0.4999707, y: -0.5}
-  m_VertexDistance: 0.0005
-  m_OffsetDistance: 0.00005
-  m_UseDelaunayMesh: 0
-  m_CompositeGameObject: {fileID: 1864824149}
 --- !u!61 &1864824154
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -1951,7 +1889,7 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_CompositeOperation: 4
+  m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:


### PR DESCRIPTION
Cleans up an unnecessary Composite Collider from ball.
Simply put, nothing else should change from the last PRs (#36 & #39)