### PR TITLE
Make ball reset position and serve when someone scores (but does not win)

### DIFF
--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -63,7 +63,7 @@ public class Ball : MonoBehaviour
     }
 
     // See NewRoundCoroutine.
-    void StartNewRound(float ang)
+    public void StartNewRound(float ang)
     {
         // https://stackoverflow.com/questions/30056471/how-to-make-the-script-wait-sleep-in-a-simple-way-in-unity
         StartCoroutine(NewRoundCoroutine(ang));

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -10,7 +10,7 @@ public class Ball : MonoBehaviour
 
     // TEMPORARY VARIABLE - angle at which the ball is served
     // TODO - MAKE THIS ANGLE CHANGE THRUOUT THE GAME!
-    private float TEMPServeAngle { get; } = 3 * Mathf.PI / 4;
+    public float TEMPServeAngle { get; private set; } = 3 * Mathf.PI / 4;
 
     // the RB node for the ball is here.
     Rigidbody2D ballRB;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -15,6 +15,9 @@ public class GameManager : MonoBehaviour
     public TextMeshProUGUI txtBoxL;
     public TextMeshProUGUI txtBoxR;
 
+    // what angle will the ball be served at next?
+    private float servingAngle;
+
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -27,7 +30,10 @@ public class GameManager : MonoBehaviour
 
         //Find the single instance of the Ball script in the scene.
         ballRef = FindFirstObjectByType<Ball>(); //assigns reference
-        
+
+        // sets the serving angle
+        // NOTE: THIS IS TEMPORARY! SEE GITHUB #37
+        servingAngle = ballRef.TEMPServeAngle;
     }
 
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -94,7 +94,11 @@ public class GameManager : MonoBehaviour
             }
 
             //GameOver();
+            return;
         }
+
+        // if no one won, serve the ball
+        ballRef.StartNewRound(servingAngle);
     }
 
     //Resets the game


### PR DESCRIPTION
This PR fixes #41.
- In Ball.cs, members StartNewRound() and TEMPServeAngle have been exposed to the public. As a reminder, TEMPServeAngle is a temporary variable while #37 is being worked on.
- In GameManager.cs, AddToScore() now terminates when someone wins.
- In GameManager.cs, AddToScore() now calls StartNewRound() on the current Ball object in the scene in the case a winner has not been determined yet.

Reviewers should:
- [ ] Test that the ball resets its position and then serves once hitting the goal area on both sides.

Known issues that won't be fixed here (Unless a reviewer requests otherwise):
- Pressing space will still reset the ball and the score, as mentioned in #44 and #42.
- The ball is served at the same angle every time, as mentioned in #37.