### PR TITLE
GM.cs - remove GameOver call on pressing space

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -68,11 +68,6 @@ public class GameManager : MonoBehaviour
             ballRef.leftScored = false;
         }
 
-        if (Input.GetKeyDown("space"))      //test: reset
-        {
-            GameOver();
-        }
-
         if (Input.GetKeyDown("escape"))      //pause the game
         {
             PauseGame();


### PR DESCRIPTION
Resolves #44.
The scores should not reset when space is pressed.

WON'T FIX:
#42 - Addressed in #66.