### PR TITLE
Update .gitattributes to ignore ShaderLab code on project profile.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -163,3 +163,5 @@ Packages/packages-lock.json linguist-generated
 
 # Exceptions for .asset files such as lightning pre-baking
 LightingData.asset     binary
+
+Assets/TextMesh?Pro/** linguist-generated


### PR DESCRIPTION
Added exceptions for TextMesh Pro files so that the main GitHub code page does not have ShaderLab as the main programming language of the project, when it's not.

Doing this so the project page appears cleaner and more focused on C# so that potential portfolio reviewers can easily identify what code we actually edit by hand.

(It also won't actually ignore these files from the project's repository, it just tells GitHub to ignore these files when it comes to it's language detection and statistics.)