### PR TITLE
Remove License Incompatibity in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Don't want to download? No problem!
 
 ## License
 
-Licensed under [GNU General Public License](LICENSE).
+Licensed under [to be addressed]


### PR DESCRIPTION
We cannot use GNU Licensing for Unity Projects.
Like legally we cannot, so we need to remove this.