### PR TITLE
Music loops on awake too

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -7410,7 +7410,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 0}
-  m_PlayOnAwake: 0
+  m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
   Loop: 1


### PR DESCRIPTION
Background music wasn't looping for other screens, so I toggled play on Awake as well.
It should now loop forever. 

Works on my end and tested this by leaving the game open in Editor and on test build, for hours. Hoping it's the same result for others.

Resolves #94 

PS: just know that there's a slow-low period of the song towards the end, but it loops back to the start seamlessly).