### PR TITLE
Rename method call on music volume slider: UpdateVolume -> UpdateMusicVolume

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -5013,7 +5013,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1003852000}
         m_TargetAssemblyTypeName: AudioManager, Assembly-CSharp
-        m_MethodName: UpdateVolume
+        m_MethodName: UpdateMusicVolume
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}


### PR DESCRIPTION
Resolves #120. Reconnects the music volume slider (settings menu) to the music volume.
- The music volume should now dynamically change upon the slider's changing.
- No other behavior should occur.